### PR TITLE
Fix to clientTrackingID so it's never null

### DIFF
--- a/src/application/standard/application.logic.workflows/filesendadapter/workflow.json
+++ b/src/application/standard/application.logic.workflows/filesendadapter/workflow.json
@@ -1180,7 +1180,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/src/application/standard/application.logic.workflows/ftpsendadapter/workflow.json
+++ b/src/application/standard/application.logic.workflows/ftpsendadapter/workflow.json
@@ -1154,7 +1154,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/src/application/standard/application.logic.workflows/httpsendadapter/workflow.json
+++ b/src/application/standard/application.logic.workflows/httpsendadapter/workflow.json
@@ -1073,7 +1073,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/src/application/standard/application.logic.workflows/sftpsendadapter/workflow.json
+++ b/src/application/standard/application.logic.workflows/sftpsendadapter/workflow.json
@@ -1154,7 +1154,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/src/application/workflows/messagesuspendprocessor/messagesuspendprocessor.logicapp.json
+++ b/src/application/workflows/messagesuspendprocessor/messagesuspendprocessor.logicapp.json
@@ -103,7 +103,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "operationOptions": "EnableSchemaValidation",

--- a/src/endpoints/file/send/filesendadapter.logicapp.json
+++ b/src/endpoints/file/send/filesendadapter.logicapp.json
@@ -122,7 +122,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/endpoints/ftp/send/ftpsendadapter.logicapp.json
+++ b/src/endpoints/ftp/send/ftpsendadapter.logicapp.json
@@ -144,7 +144,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/endpoints/http/send/httpsendadapter.logicapp.json
+++ b/src/endpoints/http/send/httpsendadapter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/endpoints/messageconstructor/messageconstructor.logicapp.json
+++ b/src/endpoints/messageconstructor/messageconstructor.logicapp.json
@@ -116,7 +116,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/endpoints/sftp/send/sftpsendadapter.logicapp.json
+++ b/src/endpoints/sftp/send/sftpsendadapter.logicapp.json
@@ -144,7 +144,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/contentdemoter/contentdemoter.logicapp.json
+++ b/src/intermediaries/contentdemoter/contentdemoter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/contentpromoter/contentpromoter.logicapp.json
+++ b/src/intermediaries/contentpromoter/contentpromoter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/flatfiledecoder/flatfiledecoder.logicapp.json
+++ b/src/intermediaries/flatfiledecoder/flatfiledecoder.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/jsondecoder/jsondecoder.logicapp.json
+++ b/src/intermediaries/jsondecoder/jsondecoder.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/jsonencoder/jsonencoder.logicapp.json
+++ b/src/intermediaries/jsonencoder/jsonencoder.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/jsondecoder/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/jsondecoder/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/jsonencoder/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/jsonencoder/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/messagesuspendprocessor/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/messagesuspendprocessor/workflow.json
@@ -728,7 +728,7 @@
                 },
                 "operationOptions": "EnableSchemaValidation",
                 "correlation": {
-                    "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                    "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                 }
             }
         },

--- a/src/intermediaries/standard/systemapplication.logic.workflows/xmlenvelopewrapper/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/xmlenvelopewrapper/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessageprocessor/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessageprocessor/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessagetranslator/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessagetranslator/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessagevalidator/workflow.json
+++ b/src/intermediaries/standard/systemapplication.logic.workflows/xmlmessagevalidator/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/src/intermediaries/topicpublisher/topicpublisher.logicapp.json
+++ b/src/intermediaries/topicpublisher/topicpublisher.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/xmlenvelopewrapper/xmlenvelopewrapper.logicapp.json
+++ b/src/intermediaries/xmlenvelopewrapper/xmlenvelopewrapper.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/xmlmessageprocessor/xmlmessageprocessor.logicapp.json
+++ b/src/intermediaries/xmlmessageprocessor/xmlmessageprocessor.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/xmlmessagetranslator/xmlmessagetranslator.logicapp.json
+++ b/src/intermediaries/xmlmessagetranslator/xmlmessagetranslator.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/src/intermediaries/xmlmessagevalidator/xmlmessagevalidator.logicapp.json
+++ b/src/intermediaries/xmlmessagevalidator/xmlmessagevalidator.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/application/standard/application.logic.workflows/filesendadapter/workflow.json.liquid
+++ b/templates/application/standard/application.logic.workflows/filesendadapter/workflow.json.liquid
@@ -1180,7 +1180,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/templates/application/standard/application.logic.workflows/ftpsendadapter/workflow.json.liquid
+++ b/templates/application/standard/application.logic.workflows/ftpsendadapter/workflow.json.liquid
@@ -1154,7 +1154,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/templates/application/standard/application.logic.workflows/httpsendadapter/workflow.json.liquid
+++ b/templates/application/standard/application.logic.workflows/httpsendadapter/workflow.json.liquid
@@ -1073,7 +1073,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/templates/application/standard/application.logic.workflows/sftpsendadapter/workflow.json.liquid
+++ b/templates/application/standard/application.logic.workflows/sftpsendadapter/workflow.json.liquid
@@ -1154,7 +1154,7 @@
 					"schema": {}
 				},
 				"correlation": {
-					"clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+					"clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
 				}
 			}
 		},

--- a/templates/application/workflows/messagesuspendprocessor/messagesuspendprocessor.logicapp.json
+++ b/templates/application/workflows/messagesuspendprocessor/messagesuspendprocessor.logicapp.json
@@ -103,7 +103,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "operationOptions": "EnableSchemaValidation",

--- a/templates/endpoints/file/send/filesendadapter.logicapp.json
+++ b/templates/endpoints/file/send/filesendadapter.logicapp.json
@@ -122,7 +122,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/endpoints/ftp/send/ftpsendadapter.logicapp.json
+++ b/templates/endpoints/ftp/send/ftpsendadapter.logicapp.json
@@ -144,7 +144,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/endpoints/http/send/httpsendadapter.logicapp.json
+++ b/templates/endpoints/http/send/httpsendadapter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/endpoints/messageconstructor/messageconstructor.logicapp.json
+++ b/templates/endpoints/messageconstructor/messageconstructor.logicapp.json
@@ -116,7 +116,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@guid()"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/endpoints/messageconstructor/messageconstructor.logicapp.json
+++ b/templates/endpoints/messageconstructor/messageconstructor.logicapp.json
@@ -116,7 +116,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@guid()"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/endpoints/sftp/send/sftpsendadapter.logicapp.json
+++ b/templates/endpoints/sftp/send/sftpsendadapter.logicapp.json
@@ -144,7 +144,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/contentdemoter/contentdemoter.logicapp.json
+++ b/templates/intermediaries/contentdemoter/contentdemoter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/contentpromoter/contentpromoter.logicapp.json
+++ b/templates/intermediaries/contentpromoter/contentpromoter.logicapp.json
@@ -111,7 +111,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/flatfilemessageprocessor/flatfilemessageprocessor.logicapp.json
+++ b/templates/intermediaries/flatfilemessageprocessor/flatfilemessageprocessor.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/jsondecoder/jsondecoder.logicapp.json
+++ b/templates/intermediaries/jsondecoder/jsondecoder.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/jsonencoder/jsonencoder.logicapp.json
+++ b/templates/intermediaries/jsonencoder/jsonencoder.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/procmgr/snippets/cons/inv/processmanager.channel.trigger.http.snippet.json
+++ b/templates/intermediaries/procmgr/snippets/cons/inv/processmanager.channel.trigger.http.snippet.json
@@ -2,7 +2,7 @@
     "workflowTrigger": {
         "manual": {
             "correlation": {
-                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
             },
             "type": "Request",
             "kind": "Http",

--- a/templates/intermediaries/procmgr/snippets/std/inv/processmanager.channel.trigger.http.snippet.json
+++ b/templates/intermediaries/procmgr/snippets/std/inv/processmanager.channel.trigger.http.snippet.json
@@ -2,7 +2,7 @@
     "workflowTrigger": {
         "manual": {
             "correlation": {
-                "clientTrackingId": "triggerBody()?['header']?['properties']?['trackingId']"
+                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
             },
             "type": "Request",
             "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/jsondecoder/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/jsondecoder/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/jsonencoder/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/jsonencoder/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/messagesuspendprocessor/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/messagesuspendprocessor/workflow.json
@@ -728,7 +728,7 @@
                 },
                 "operationOptions": "EnableSchemaValidation",
                 "correlation": {
-                    "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                    "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                 }
             }
         },

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/xmlenvelopewrapper/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/xmlenvelopewrapper/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessageprocessor/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessageprocessor/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessagetranslator/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessagetranslator/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessagevalidator/workflow.json
+++ b/templates/intermediaries/standard/systemapplication.logic.workflows/xmlmessagevalidator/workflow.json
@@ -5,7 +5,7 @@
     "triggers": {
       "manual": {
         "correlation": {
-          "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+          "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
         },
         "type": "Request",
         "kind": "Http",

--- a/templates/intermediaries/topicpublisher/topicpublisher.logicapp.json
+++ b/templates/intermediaries/topicpublisher/topicpublisher.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/xmlenvelopewrapper/xmlenvelopewrapper.logicapp.json
+++ b/templates/intermediaries/xmlenvelopewrapper/xmlenvelopewrapper.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/xmlmessageprocessor/xmlmessageprocessor.logicapp.json
+++ b/templates/intermediaries/xmlmessageprocessor/xmlmessageprocessor.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/xmlmessagetranslator/xmlmessagetranslator.logicapp.json
+++ b/templates/intermediaries/xmlmessagetranslator/xmlmessagetranslator.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",

--- a/templates/intermediaries/xmlmessagevalidator/xmlmessagevalidator.logicapp.json
+++ b/templates/intermediaries/xmlmessagevalidator/xmlmessagevalidator.logicapp.json
@@ -121,7 +121,7 @@
                     "triggers": {
                         "manual": {
                             "correlation": {
-                                "clientTrackingId": "@triggerBody()?['header']?['properties']?['trackingId']"
+                                "clientTrackingId": "@coalesce(triggerBody()?['header']?['properties']?['trackingId'], guid())"
                             },
                             "type": "Request",
                             "kind": "Http",


### PR DESCRIPTION
## Description
- Updated clientTrackingId expression to use guid() if no value found

## Related GitHub issue(s)
None

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.