### PR TITLE
Chocolatey verification file fixes

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -61,15 +61,16 @@ jobs:
       - name: Create the Chocolatey verification file and copy the license file
         shell: bash
         run: |         
-          mkdir -p ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}
+          mkdir -p ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}     
           cp ./LICENSE ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}/LICENSE.txt
-          verificationFile=./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}/VERIFICATION.txt
-          touch $verificationFile
-          find ./templates -type f  | 
+          cp ./VERIFICATION ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}/VERIFICATION.txt
+          echo "Checksums for the files in the package are:" >> ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}/VERIFICATION.txt
+          find ${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }} -type f  | 
           while read f
           do
-            filename="$basename -- $f"
-            echo $filename >> $verificationFile
+            filename="$(basename $f) [$f]"
+            filehash=$(sha256sum $f | awk '{print $1}')
+            echo "$filename -- $filehash" >> ./${{ env.OUTPUT_DIR }}/${{ env.CHOCO_SRC_DIR }}/VERIFICATION.txt
           done
 
       - name: Create the Chocolatey package output directory

--- a/VERIFICATION
+++ b/VERIFICATION
@@ -1,0 +1,21 @@
+VERIFICATION
+Verification is intended to assist Chocolatey moderators and the Chocolatey community
+in verifying that this package's contents are trustworthy.
+
+This package contains liquid template files, json files, powershell scripts, and a couple of zip files (containing Azure Functions).
+This file lists their SHA256 checksums.
+
+There is no other source for installation of these files, other than Chocolatey: 
+The files are built and packaged and uploaded to Chocolatey; other than referenced files (e.g. .NET Core), they do not currently reside in any other public source.
+Therefore, it is not possible to download an installer to compare checksums.
+
+However, the checksums in here are generated as part of the build process,
+and reflect the files that are packaged and submitted to Chocolatey.
+
+It is still worthwhile comparing the checksums in this file to the ones for the files that have been installed by Chocolatey on your local system.
+
+You can use one of the following methods to obtain the checksum from a local file:
+  - Use powershell function 'Get-Filehash'
+  - Use chocolatey utility 'checksum.exe'
+
+File 'LICENSE.txt' is obtained from <https://github.com/Azure/aimazure/blob/main/LICENSE>

--- a/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec
+++ b/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec
@@ -4,8 +4,10 @@
     <id>biztalkmigrator-azure</id>
     <!-- Note This version will be overriden by the command line. -->
     <version>0.0.1-beta</version>
-    <packageSourceUrl>https://github.com/azure/aimazure</packageSourceUrl>
+    <packageSourceUrl>https://github.com/Azure/aimazure/blob/main/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec</packageSourceUrl>
+    <projectSourceUrl>https://github.com/azure/aimazure</projectSourceUrl>
     <title>BizTalk Migrator Dependency - Azure Templates</title>
+    <owners>probertdaniel,345paul,valrobb</owners>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/azure/aimazure</projectUrl>
     <projectSourceUrl>https://github.com/azure/aimazure</projectSourceUrl>

--- a/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec
+++ b/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec
@@ -5,7 +5,6 @@
     <!-- Note This version will be overriden by the command line. -->
     <version>0.0.1-beta</version>
     <packageSourceUrl>https://github.com/Azure/aimazure/blob/main/build/chocolatey/biztalkmigrator-azure/biztalkmigrator-azure.nuspec</packageSourceUrl>
-    <projectSourceUrl>https://github.com/azure/aimazure</projectSourceUrl>
     <title>BizTalk Migrator Dependency - Azure Templates</title>
     <owners>probertdaniel,345paul,valrobb</owners>
     <authors>Microsoft</authors>


### PR DESCRIPTION
## Description
- Update Verification file to list checksums for all files
- Updated ci build to create verification file
- Updated nuspec as per chocolatey moderator comments

## Related GitHub issue(s)
Please tag the related issues.

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.